### PR TITLE
Add absolute URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ The required options are wrapped in the `instance` key of the options object. Yo
    - While you're free to use the default Client ID provided by Ghost (`ghost-frontend`), we strongly recommend you [create a new one](https://api.ghost.org/docs/ajax-calls-from-an-external-website#section-how-to-edit-the-database) for better security and tracking
  - Client Secret (`clientSecret`) - The Client Secret used to authenticate `clientID` (this is how oAuth works) via the [Ghost API](https://api.ghost.org/)
 
- There is one optional parameter, `includePages`, which is defaulted to `false`. Setting this option to anything truthy will add blog pages to the index
+Optional Paramaters:
+
+- Include Pages (`includePages`) - defaulted to `false`; setting this option to anything truthy will add blog pages to the index
+- Absolute URLs (`absolute`) - defaulted to `true`; setting this option to anything falsy will return the relative url. If you're hosting your blog on a subdomain (i.e. https://www.example.com/blog), you should keep this as true, unless you plan on adding the path to your render template
 
  #### Example
 
@@ -71,7 +74,8 @@ const myInstance = new GhostHunter({
     clientID: 'ghost-search',
     clientSecret: 'abcd1ef2gh3'
   },
-  includePages: true
+  includePages: true,
+  absolute: false
 });
  ```
 
@@ -105,7 +109,8 @@ const searchInstance = new Server({
       clientID: 'ghost-search',
       clientSecret: 'abcd1ef2gh3'
     },
-    includePages: true
+	includePages: true,
+	absolute: false
   },
   allowedOrigins: ['blog.demo.com', 'demo.ghost.io']
 });
@@ -127,6 +132,8 @@ Both the initialized GhostHunter Class and server drop-in have properties bound 
 `blogData` - An object with keys (determined by Post ID) mapping to post data. Used by original GhostHunter
 
 `includePages` - Whether or not pages should be included in the index
+
+`absolute` - Whether or not absolute URLs should be used for posts when building blog data
 
 `instance` - The instance properties you need to provide for GhostHunter to request data
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ There are a couple of notable differences compared to the original GhostHunter:
 
 ## Backend
 
-No documented differences. If you find one, please [report it](#issues-and-support)
+ - The API can respond with absolute URLs to posts
+
+If you find any other differences, please [report it](#issues-and-support)
 
 # Installation
 

--- a/lib/ghost-hunter.js
+++ b/lib/ghost-hunter.js
@@ -3,6 +3,7 @@
 */
 
 const assert = require('assert');
+const {resolve} = require('url');
 const lunr = require('lunr');
 const got = require('got');
 
@@ -30,7 +31,8 @@ class GhostHunter {
 	constructor(_options = {}) {
 		const options = Object.assign({
 			instance: {},
-			includePages: false
+			includePages: false,
+			absolute: true
 		}, _options);
 
 		this.initialized = false;
@@ -92,6 +94,7 @@ class GhostHunter {
 					pubDate: String(post.created_at),
 					tag: tags,
 					featureImage: String(post.feature_image),
+					// We don't want this to be an absolute url because it's of no use to the index
 					link: String(post.url)
 				};
 				parsedData.prettyPubDate = prettyDate(parsedData.pubDate);
@@ -101,7 +104,7 @@ class GhostHunter {
 					description: post.meta_description,
 					pubDate: parsedData.prettyPubDate,
 					featureImage: post.feature_image,
-					link: post.url
+					link: this.absolute ? resolve(this.instance.url, post.url) : post.url
 				};
 				return parsedData;
 			});


### PR DESCRIPTION
no issue ref

Add support for responding with absolute URLs to the post rather than relative.

This is really important for blogs that are mounted to a subdirectory since the API will return absolute URLs without the subdir